### PR TITLE
chore: release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1](https://github.com/a5ehren/compiledb-rs/compare/v1.2.0...v1.2.1) - 2026-08-12
+
+### Other
+
+- update gh actions
+
 ## [1.2.0](https://github.com/a5ehren/compiledb-rs/compare/v1.1.5...v1.2.0) - 2026-08-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compiledb"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiledb"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 authors = ["Original: fcying, Rust port: a5ehren"]
 description = "Clang's Compilation Database generator for make-based build systems"


### PR DESCRIPTION



## 🤖 New release

* `compiledb`: 1.2.0 -> 1.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.2.1](https://github.com/a5ehren/compiledb-rs/compare/v1.2.0...v1.2.1) - 2026-08-12

### Other

- update gh actions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).